### PR TITLE
Fix Combo not incrementing at all, fixes #3

### DIFF
--- a/Harmony/BeatmapObjectExecutionRatingsRecorder.cs
+++ b/Harmony/BeatmapObjectExecutionRatingsRecorder.cs
@@ -15,6 +15,7 @@ namespace DataPuller.Harmony
             {
                 if (scoringElement is GoodCutScoringElement goodCutScoringElement)
                 {
+                    LiveData.Instance.Combo++;
                     LiveData.Instance.BlockHitScore = new()
                     {
                         PreSwing = goodCutScoringElement.cutScoreBuffer.beforeCutScore,


### PR DESCRIPTION
This fixes #3 . It looks like in reducing the doubling of a combo, both ways to increment the combo were removed. This adds one back in the same place the score is added.