### PR TITLE
Use MultiplayerCore NetworkConfigPatcher for reliable lobby source detection

### DIFF
--- a/Data/MapData.cs
+++ b/Data/MapData.cs
@@ -252,9 +252,18 @@ namespace DataPuller.Data
         public string? MultiplayerLobbyJoinCode { get; internal set; }
 
         /// <summary>The multiplayer backend for the current lobby, as a string matching <see cref="MultiplayerLobbySourceType"/> member names.</summary>
-        /// <remarks><see href="null"/> when not in multiplayer. Possible values: <c>Vanilla</c>, <c>BeatTogether</c>, <c>BeatSaberPlus_Multiplayer</c>.</remarks>
+        /// <remarks><see href="null"/> when not in multiplayer. Possible values: <c>Vanilla</c>, <c>MultiplayerCore</c>, <c>BeatTogether</c>, <c>BeatSaberPlus_Multiplayer</c>.</remarks>
         /// <value>Default is <see href="null"/>.</value>
         public string? MultiplayerLobbySource { get; internal set; }
+
+        /// <summary>The name of the specific mod or server powering the current MultiplayerCore-backed lobby (e.g. "BeatTogether").</summary>
+        /// <remarks>
+        /// Only populated when <see cref="MultiplayerLobbySource"/> is <see cref="MultiplayerLobbySourceType.MultiplayerCore"/>.
+        /// Corresponds to the <c>name</c> field in the server's MultiplayerCore status response.
+        /// <see href="null"/> otherwise.
+        /// </remarks>
+        /// <value>Default is <see href="null"/>.</value>
+        public string? MultiplayerLobbyModName { get; internal set; }
 
         /// <summary>Whether the current BeatSaberPlus Multiplayer+ lobby is private.</summary>
         /// <remarks><see href="null"/> when not in multiplayer or source is not BeatSaberPlus.</remarks>

--- a/Data/MapData.cs
+++ b/Data/MapData.cs
@@ -252,7 +252,7 @@ namespace DataPuller.Data
         public string? MultiplayerLobbyJoinCode { get; internal set; }
 
         /// <summary>The multiplayer backend for the current lobby, as a string matching <see cref="MultiplayerLobbySourceType"/> member names.</summary>
-        /// <remarks><see href="null"/> when not in multiplayer. Possible values: <c>Vanilla</c>, <c>MultiplayerCore</c>, <c>BeatTogether</c>, <c>BeatSaberPlus_Multiplayer</c>.</remarks>
+        /// <remarks><see href="null"/> when not in multiplayer. Possible values: <c>Vanilla</c>, <c>MultiplayerCore</c>, <c>BeatSaberPlus_Multiplayer</c>.</remarks>
         /// <value>Default is <see href="null"/>.</value>
         public string? MultiplayerLobbySource { get; internal set; }
 
@@ -263,7 +263,7 @@ namespace DataPuller.Data
         /// <see href="null"/> otherwise.
         /// </remarks>
         /// <value>Default is <see href="null"/>.</value>
-        public string? MultiplayerLobbyModName { get; internal set; }
+        public string? MultiplayerCoreLobbyMod { get; internal set; }
 
         /// <summary>Whether the current BeatSaberPlus Multiplayer+ lobby is private.</summary>
         /// <remarks><see href="null"/> when not in multiplayer or source is not BeatSaberPlus.</remarks>

--- a/Data/MapData.cs
+++ b/Data/MapData.cs
@@ -224,9 +224,16 @@ namespace DataPuller.Data
 
         /// <summary></summary>
         /// <remarks></remarks>
+        /// <value>Always <c>"2.1.1"</c> for compatibility with BSDP-Overlay version detection. See <see cref="ModVersion"/> for the real version.</value>
+        [JsonProperty]
+        [Obsolete("Use ModVersion for the actual plugin version. This field is frozen at 2.1.1 for BSDP-Overlay compatibility.")]
+        public static readonly string PluginVersion = "2.1.1";
+
+        /// <summary>The real version of this plugin.</summary>
+        /// <remarks></remarks>
         /// <value><see cref="Version"/>.</value>
         [JsonProperty]
-        public static readonly string PluginVersion = Assembly.GetExecutingAssembly().GetName().Version.ToString(3);
+        public static readonly string ModVersion = Assembly.GetExecutingAssembly().GetName().Version.ToString(3);
 
         /// <summary></summary>
         /// <remarks></remarks>

--- a/Data/MultiplayerLobbySourceType.cs
+++ b/Data/MultiplayerLobbySourceType.cs
@@ -10,15 +10,9 @@ namespace DataPuller.Data
         public const string Vanilla = "Vanilla";
 
         /// <summary>
-        /// BeatTogether mod — extends vanilla multiplayer with cross-platform and custom-song support.
-        /// BSIPA plugin ID: <c>BeatTogether</c>.
-        /// </summary>
-        public const string BeatTogether = "BeatTogether";
-
-        /// <summary>
         /// Any custom multiplayer server backed by the MultiplayerCore mod.
         /// BSIPA plugin ID: <c>MultiplayerCore</c>.
-        /// The specific server or mod can be identified via <see cref="MapData.MultiplayerLobbyModName"/>.
+        /// The specific server or mod can be identified via <see cref="MapData.MultiplayerCoreLobbyMod"/>.
         /// </summary>
         public const string MultiplayerCore = "MultiplayerCore";
 

--- a/Data/MultiplayerLobbySourceType.cs
+++ b/Data/MultiplayerLobbySourceType.cs
@@ -16,6 +16,13 @@ namespace DataPuller.Data
         public const string BeatTogether = "BeatTogether";
 
         /// <summary>
+        /// Any custom multiplayer server backed by the MultiplayerCore mod.
+        /// BSIPA plugin ID: <c>MultiplayerCore</c>.
+        /// The specific server or mod can be identified via <see cref="MapData.MultiplayerLobbyModName"/>.
+        /// </summary>
+        public const string MultiplayerCore = "MultiplayerCore";
+
+        /// <summary>
         /// BeatSaberPlus Multiplayer+ mod — fully custom multiplayer networking.
         /// BSIPA plugin ID: <c>BeatSaberPlus_Multiplayer</c>.
         /// </summary>

--- a/Multiplayer/VanillaMultiplayerSource.cs
+++ b/Multiplayer/VanillaMultiplayerSource.cs
@@ -152,7 +152,7 @@ namespace DataPuller.Multiplayer
                 var repo = ProjectContext.Instance.Container.TryResolve(repoType);
                 if (repo == null) return null;
 
-                var status = repoType.GetMethod("GetStatusForUrl")?.Invoke(repo, new object[] { statusUrl });
+                var status = repoType.GetMethod("GetStatusForUrl")?.Invoke(repo, new object[] { statusUrl! });
                 return status?.GetType().GetProperty("name")?.GetValue(status) as string;
             }
             catch (Exception ex)

--- a/Multiplayer/VanillaMultiplayerSource.cs
+++ b/Multiplayer/VanillaMultiplayerSource.cs
@@ -35,7 +35,7 @@ namespace DataPuller.Multiplayer
             MapData.Instance.IsMultiplayer = false;
             MapData.Instance.MultiplayerLobbyJoinCode = null;
             MapData.Instance.MultiplayerLobbySource = null;
-            MapData.Instance.MultiplayerLobbyModName = null;
+            MapData.Instance.MultiplayerCoreLobbyMod = null;
             MapData.Instance.MultiplayerLobbyIsPrivate = null;
             _maxPlayerCount = 0;
 
@@ -83,15 +83,12 @@ namespace DataPuller.Multiplayer
             {
                 if (source != null)
                     MapData.Instance.MultiplayerLobbySource = source;
-                MapData.Instance.MultiplayerLobbyModName = modName;
+                MapData.Instance.MultiplayerCoreLobbyMod = modName;
                 return;
             }
 
-            // Fallback when MultiplayerCore is absent: infer from plugin presence.
-            MapData.Instance.MultiplayerLobbySource = PluginManager.GetPluginFromId("BeatTogether") != null
-                ? MultiplayerLobbySourceType.BeatTogether
-                : MultiplayerLobbySourceType.Vanilla;
-            MapData.Instance.MultiplayerLobbyModName = null;
+            MapData.Instance.MultiplayerLobbySource = MultiplayerLobbySourceType.Vanilla;
+            MapData.Instance.MultiplayerCoreLobbyMod = null;
         }
 
         /// <summary>

--- a/Multiplayer/VanillaMultiplayerSource.cs
+++ b/Multiplayer/VanillaMultiplayerSource.cs
@@ -1,11 +1,17 @@
 using DataPuller.Data;
 using IPA.Loader;
+using System;
+using System.Linq;
+using System.Reflection;
+using Zenject;
 
 #nullable enable
 namespace DataPuller.Multiplayer
 {
     internal class VanillaMultiplayerSource : IMultiplayerSource
     {
+        private const string MultiplayerCoreId = "MultiplayerCore";
+
         private BeatSaberConnectedPlayerManager? _connectedPlayerManager;
         private int _maxPlayerCount;
 
@@ -50,6 +56,11 @@ namespace DataPuller.Multiplayer
         internal void SetLobbyCode(string code)
         {
             MapData.Instance.MultiplayerLobbyJoinCode = code;
+            // By the time a lobby code is displayed the server status endpoint will have
+            // been contacted. Re-resolve the source name in case it wasn't available yet
+            // when Activate() ran.
+            if (TryGetMultiplayerCoreSource(out var refreshedSource) && refreshedSource != null)
+                MapData.Instance.MultiplayerLobbySource = refreshedSource;
             MapData.Instance.Send();
         }
 
@@ -67,8 +78,82 @@ namespace DataPuller.Multiplayer
         private void OnPlayerChanged(object _) => UpdatePlayerCount();
 
         private static string DetectSource()
-            => PluginManager.GetPluginFromId("BeatTogether") != null
+        {
+            if (TryGetMultiplayerCoreSource(out var source) && source != null)
+                return source;
+
+            // Fallback when MultiplayerCore is absent or server name not yet available:
+            // infer from plugin presence.
+            return PluginManager.GetPluginFromId("BeatTogether") != null
                 ? MultiplayerLobbySourceType.BeatTogether
                 : MultiplayerLobbySourceType.Vanilla;
+        }
+
+        /// <summary>
+        /// Attempts to detect the lobby source using MultiplayerCore's NetworkConfigPatcher.
+        /// Returns false if MultiplayerCore is not installed or an error occurs.
+        /// Returns true with a null <paramref name="source"/> if MultiplayerCore is overriding
+        /// the API but the server name is not yet available from the status endpoint.
+        /// </summary>
+        private static bool TryGetMultiplayerCoreSource(out string? source)
+        {
+            source = null;
+            if (PluginManager.GetPluginFromId(MultiplayerCoreId) == null) return false;
+            try
+            {
+                var asm = AppDomain.CurrentDomain.GetAssemblies()
+                    .FirstOrDefault(a => a.GetName().Name == MultiplayerCoreId);
+                if (asm == null) return false;
+
+                var patcherType = asm.GetType("MultiplayerCore.Patchers.NetworkConfigPatcher");
+                if (patcherType == null) return false;
+
+                var patcher = ProjectContext.Instance.Container.TryResolve(patcherType);
+                if (patcher == null) return false;
+
+                var isOverriding = patcherType.GetProperty("IsOverridingApi")?.GetValue(patcher) as bool?;
+                if (isOverriding == false)
+                {
+                    source = MultiplayerLobbySourceType.Vanilla;
+                    return true;
+                }
+
+                if (isOverriding == true)
+                {
+                    source = GetMultiplayerCoreServerName(asm, patcher, patcherType);
+                    return true;
+                }
+
+                return false;
+            }
+            catch (Exception ex)
+            {
+                Plugin.Logger.Debug($"MultiplayerCore source detection failed: {ex.Message}");
+                return false;
+            }
+        }
+
+        private static string? GetMultiplayerCoreServerName(Assembly asm, object patcher, Type patcherType)
+        {
+            try
+            {
+                var statusUrl = patcherType.GetProperty("MasterServerStatusUrl")?.GetValue(patcher) as string;
+                if (string.IsNullOrEmpty(statusUrl)) return null;
+
+                var repoType = asm.GetType("MultiplayerCore.Repositories.MpStatusRepository");
+                if (repoType == null) return null;
+
+                var repo = ProjectContext.Instance.Container.TryResolve(repoType);
+                if (repo == null) return null;
+
+                var status = repoType.GetMethod("GetStatusForUrl")?.Invoke(repo, new object[] { statusUrl });
+                return status?.GetType().GetProperty("name")?.GetValue(status) as string;
+            }
+            catch (Exception ex)
+            {
+                Plugin.Logger.Debug($"MultiplayerCore server name lookup failed: {ex.Message}");
+                return null;
+            }
+        }
     }
 }

--- a/Multiplayer/VanillaMultiplayerSource.cs
+++ b/Multiplayer/VanillaMultiplayerSource.cs
@@ -24,7 +24,7 @@ namespace DataPuller.Multiplayer
             _connectedPlayerManager.playerDisconnectedEvent += OnPlayerChanged;
 
             MapData.Instance.IsMultiplayer = true;
-            MapData.Instance.MultiplayerLobbySource = DetectSource();
+            ApplySource();
             UpdatePlayerCount();
         }
 
@@ -35,6 +35,7 @@ namespace DataPuller.Multiplayer
             MapData.Instance.IsMultiplayer = false;
             MapData.Instance.MultiplayerLobbyJoinCode = null;
             MapData.Instance.MultiplayerLobbySource = null;
+            MapData.Instance.MultiplayerLobbyModName = null;
             MapData.Instance.MultiplayerLobbyIsPrivate = null;
             _maxPlayerCount = 0;
 
@@ -57,10 +58,9 @@ namespace DataPuller.Multiplayer
         {
             MapData.Instance.MultiplayerLobbyJoinCode = code;
             // By the time a lobby code is displayed the server status endpoint will have
-            // been contacted. Re-resolve the source name in case it wasn't available yet
-            // when Activate() ran.
-            if (TryGetMultiplayerCoreSource(out var refreshedSource) && refreshedSource != null)
-                MapData.Instance.MultiplayerLobbySource = refreshedSource;
+            // been contacted. Re-apply source to pick up the mod name if it wasn't
+            // available when Activate() ran.
+            ApplySource();
             MapData.Instance.Send();
         }
 
@@ -77,16 +77,21 @@ namespace DataPuller.Multiplayer
         private void OnDisconnected(DisconnectedReason _) => UpdatePlayerCount();
         private void OnPlayerChanged(object _) => UpdatePlayerCount();
 
-        private static string DetectSource()
+        private static void ApplySource()
         {
-            if (TryGetMultiplayerCoreSource(out var source) && source != null)
-                return source;
+            if (TryGetMultiplayerCoreSource(out var source, out var modName))
+            {
+                if (source != null)
+                    MapData.Instance.MultiplayerLobbySource = source;
+                MapData.Instance.MultiplayerLobbyModName = modName;
+                return;
+            }
 
-            // Fallback when MultiplayerCore is absent or server name not yet available:
-            // infer from plugin presence.
-            return PluginManager.GetPluginFromId("BeatTogether") != null
+            // Fallback when MultiplayerCore is absent: infer from plugin presence.
+            MapData.Instance.MultiplayerLobbySource = PluginManager.GetPluginFromId("BeatTogether") != null
                 ? MultiplayerLobbySourceType.BeatTogether
                 : MultiplayerLobbySourceType.Vanilla;
+            MapData.Instance.MultiplayerLobbyModName = null;
         }
 
         /// <summary>
@@ -94,10 +99,13 @@ namespace DataPuller.Multiplayer
         /// Returns false if MultiplayerCore is not installed or an error occurs.
         /// Returns true with a null <paramref name="source"/> if MultiplayerCore is overriding
         /// the API but the server name is not yet available from the status endpoint.
+        /// When overriding, <paramref name="source"/> is <see cref="MultiplayerLobbySourceType.MultiplayerCore"/>
+        /// and <paramref name="modName"/> is the server name from the status endpoint (e.g. "BeatTogether").
         /// </summary>
-        private static bool TryGetMultiplayerCoreSource(out string? source)
+        private static bool TryGetMultiplayerCoreSource(out string? source, out string? modName)
         {
             source = null;
+            modName = null;
             if (PluginManager.GetPluginFromId(MultiplayerCoreId) == null) return false;
             try
             {
@@ -120,7 +128,8 @@ namespace DataPuller.Multiplayer
 
                 if (isOverriding == true)
                 {
-                    source = GetMultiplayerCoreServerName(asm, patcher, patcherType);
+                    source = MultiplayerLobbySourceType.MultiplayerCore;
+                    modName = GetMultiplayerCoreServerName(asm, patcher, patcherType);
                     return true;
                 }
 

--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.1.18")]
-[assembly: AssemblyFileVersion("2.1.18")]
+[assembly: AssemblyVersion("3.0.0")]
+[assembly: AssemblyFileVersion("3.0.0")]

--- a/README.md
+++ b/README.md
@@ -236,11 +236,16 @@ int MultiplayerLobbyCurrentSize = 0;
 ///null when not in a multiplayer lobby, or if the code has not yet been assigned by the server.
 string? MultiplayerLobbyJoinCode = null;
 
-///The BSIPA plugin ID of the mod providing the multiplayer backend for the current lobby.
-///"Vanilla" when no known multiplayer mod is active.
-///Known values: "Vanilla", "BeatTogether", "BeatSaberPlus_Multiplayer".
+///The multiplayer backend for the current lobby.
+///"Vanilla" when MultiplayerCore is not installed or no custom server is active.
+///Known values: "Vanilla", "MultiplayerCore", "BeatSaberPlus_Multiplayer".
 ///null when not in a multiplayer lobby.
 string? MultiplayerLobbySource = null;
+
+///The name of the mod or server powering the current MultiplayerCore-backed lobby (e.g. "BeatTogether").
+///Only populated when MultiplayerLobbySource is "MultiplayerCore".
+///null when not in a multiplayer lobby, or when the source is not MultiplayerCore.
+string? MultiplayerCoreLobbyMod = null;
 
 ///Whether the current BeatSaberPlus Multiplayer+ lobby is set to private.
 ///null when not in a multiplayer lobby, or when the source is not BeatSaberPlus_Multiplayer.

--- a/README.md
+++ b/README.md
@@ -220,7 +220,9 @@ SColorScheme ColorScheme = new SColorScheme();
 //====MISC====
 string GameVersion = ""; //Will be the current game version, e.g. 1.20.0
 
-string PluginVersion = ""; //Will be the current version of the plugin, e.g. 2.1.0
+string PluginVersion = ""; //[DEPRECATED] Always "2.1.1" for BSDP-Overlay compatibility. Use ModVersion instead.
+
+string ModVersion = ""; //The actual version of this plugin, e.g. 3.0.0
 
 bool IsMultiplayer = false;
 

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "id": "DataPuller",
   "name": "DataPuller",
   "author": "ReadieFur",
-  "version": "2.1.18",
+  "version": "3.0.0",
   "description": "Gathers data about the current map you are playing to then be sent out over a websocket for other software to use, e.g. A web overlay like BSDP-Overlay. This mod works with multi PC setups!",
   "gameVersion": "1.43.0",
   "dependsOn": {


### PR DESCRIPTION
## Problem

`VanillaMultiplayerSource.DetectSource()` inferred the lobby source by checking whether the BeatTogether plugin was installed — a heuristic with two failure modes:
- **False positive:** BeatTogether installed but connecting to official servers → reported as `BeatTogether` instead of `Vanilla`
- **False negative:** Custom server active but BeatTogether not installed → reported as `Vanilla`

## Solution

Use [MultiplayerCore](https://github.com/Goobwabber/MultiplayerCore)'s public API (via reflection — no compile-time dependency) for reliable detection:

- **`NetworkConfigPatcher.IsOverridingApi == false`** → definitively `Vanilla`
- **`NetworkConfigPatcher.IsOverridingApi == true`** → source becomes `MultiplayerCore`; the specific server name from `MpStatusRepository.GetStatusForUrl(...).name` (e.g. `"BeatTogether"`) is stored separately in the new `MultiplayerCoreLobbyMod` field
- `ApplySource()` is also called from `SetLobbyCode`, where the status endpoint is guaranteed to have been contacted, to pick up the mod name if it wasn't available at `Activate()` time
- If MultiplayerCore is not installed, source is set to `Vanilla` — no other heuristic is applied

## Changes

### `Data/MultiplayerLobbySourceType.cs`
`BeatTogether` constant removed. Only `Vanilla`, `MultiplayerCore`, and `BeatSaberPlus_Multiplayer` remain.

### `Data/MapData.cs`
- Added `MultiplayerCoreLobbyMod` — the server name reported by the MultiplayerCore status endpoint (e.g. `"BeatTogether"`). Only populated when `MultiplayerLobbySource == "MultiplayerCore"`.
- `PluginVersion` is now frozen at `"2.1.1"` and marked obsolete. [BSDP-Overlay](https://github.com/ReadieFur/BSDP-Overlay) uses this field's major.minor to look up a converter file (e.g. `2.1.ts`); bumping it to `3.0` would silently break overlays that haven't been updated. The new `ModVersion` field carries the real assembly version.

### `Multiplayer/VanillaMultiplayerSource.cs`
Replaced `DetectSource()` + inline source assignment with `ApplySource()`, which sets both `MultiplayerLobbySource` and `MultiplayerCoreLobbyMod` together.

### `manifest.json` / `Properties/AssemblyInfo.cs`
Version bumped to **3.0.0**.